### PR TITLE
Upgrade snap base to core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-config-provider-example
-base: core20
+base: core22
 
 version: git
 summary: Example EdgeX snaps config provider
@@ -36,7 +36,7 @@ parts:
     # For example. to take config files from a git repository, i.e. the upstream repo:
     # source: https://github.com/edgexfoundry/device-virtual-go.git
     override-build: |
-      TARGET=$SNAPCRAFT_PART_INSTALL/device-virtual
+      TARGET=$CRAFT_PART_INSTALL/device-virtual
 
       mkdir -p $TARGET
       cp -vr res $TARGET/res


### PR DESCRIPTION
Upgrade the snap base to core22 and replace the deprecated environment variables.